### PR TITLE
cris: memory: Replace memory_region_init_ram with memory_region_allocate...

### DIFF
--- a/hw/cris/axis_dev88.c
+++ b/hw/cris/axis_dev88.c
@@ -270,9 +270,8 @@ void axisdev88_init(MachineState *machine)
     env = &cpu->env;
 
     /* allocate RAM */
-    memory_region_init_ram(phys_ram, NULL, "axisdev88.ram", ram_size,
-                           &error_abort);
-    vmstate_register_ram_global(phys_ram);
+    memory_region_allocate_system_memory(phys_ram, NULL, "axisdev88.ram",
+                                         ram_size);
     memory_region_add_subregion(address_space_mem, 0x40000000, phys_ram);
 
     /* The ETRAX-FS has 128Kb on chip ram, the docs refer to it as the 


### PR DESCRIPTION
..._system_memory

Commit 0b183fc871:"memory: move mem_path handling to
memory_region_allocate_system_memory" split memory_region_init_ram and
memory_region_init_ram_from_file. Also it moved mem-path handling a step
up from memory_region_init_ram to memory_region_allocate_system_memory.

Therefore for any board that uses memory_region_init_ram directly,
-mem-path is not supported.

Fix this by replacing memory_region_init_ram with
memory_region_allocate_system_memory.

Tested-by: Edgar E. Iglesias <edgar.iglesias@xilinx.com>
Reviewed-by: Edgar E. Iglesias <edgar.iglesias@xilinx.com>
Cc: Edgar E. Iglesias <edgar.iglesias@gmail.com>
Signed-off-by: Dirk Mueller <dmueller@suse.com>
Signed-off-by: Edgar E. Iglesias <edgar.iglesias@xilinx.com>